### PR TITLE
Fix default LCD orientation

### DIFF
--- a/Joypad_RC/tft.h
+++ b/Joypad_RC/tft.h
@@ -58,6 +58,8 @@ void TFT_init(boolean _init, boolean _rot) {
 
     if (_rot)
       tft.setRotation(2);
+    else
+      tft.setRotation(0);
   }
 
   tft.fillRect(0, 0, tft_width, 40, tft_colorA);


### PR DESCRIPTION
Hi!
I have setup my joypad today. Everything is working very nicely, except the default screen rotation!
So my screen always stared inverted ignoring the "tft_rotation" setting value, so I had to set the default rotation to 0 overwise their was no way to get it not inverted.
